### PR TITLE
Fix build for browsers

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,9 +14,13 @@ const commonConfig = {
     entry: './src/index.ts',
     output: {
         path: path.resolve(__dirname, 'dist'),
-        library: 'html2canvas',
-        libraryTarget: 'umd',
-        umdNamedDefine: true
+        library: {
+            name: 'html2canvas',
+            type: 'umd',
+            umdNamedDefine: true,
+            export: 'default'
+        },
+        globalObject: 'this'
     },
     resolve: {
         extensions: ['.ts', '.js', '.json']


### PR DESCRIPTION
**Summary**

<!-- Summary of the PR -->

This PR fixes/implements the following **bugs/features**

* [x] fixes loading the lib in browsers. might also fix #6 

When loading in the browser it complained that html2canvas was not a function. this PR fixes that

**Test plan (required)**

Demonstrate how the issue/feature can be replicated. For most cases, simply adding an appropriate html/css template into the [reftests](https://github.com/html2canvas/html2canvas/tree/master/tests/reftests) should be sufficient. Please see other tests there for reference.

**Code formatting**

Please make sure that code adheres to the project code formatting. Running `npm run format` will automatically format your code correctly.

**Closing issues**

Possibly closes #6 
