### PR TITLE
Fixes #2238 #1624 - Fix the issue of TextNode content being overlooke…

### DIFF
--- a/src/dom/node-parser.ts
+++ b/src/dom/node-parser.ts
@@ -17,8 +17,8 @@ const LIST_OWNERS = ['OL', 'UL', 'MENU'];
 const parseNodeTree = (context: Context, node: Node, parent: ElementContainer, root: ElementContainer) => {
     for (let childNode = node.firstChild, nextNode; childNode; childNode = nextNode) {
         nextNode = childNode.nextSibling;
-
-        if (isTextNode(childNode) && childNode.data.trim().length > 0) {
+        // Fixes #2238 #1624 - Fix the issue of TextNode content being overlooked in rendering due to being perceived as blank by trim().
+        if (isTextNode(childNode) && childNode.data.length > 0) {
             // The U tag marks text with a special underline treatment, and it's not possible to get the underline style from the browser's computed style.
             const parentStep = 3;
             let hasUnderline;


### PR DESCRIPTION
**Summary**

<!-- Summary of the PR -->

This PR fixes/implements the following **bugs/features**

* [x] Bug Fix the issue of TextNode content being overlooked in rendering due to being perceived as blank by trim().

**Closing issues**

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
Fixes #2238