### PR TITLE
Fixed an issue with characters moving up in non-Firefox

### DIFF
--- a/src/render/canvas/canvas-renderer.ts
+++ b/src/render/canvas/canvas-renderer.ts
@@ -187,7 +187,7 @@ export class CanvasRenderer extends Renderer {
         this.ctx.direction = styles.direction === DIRECTION.RTL ? 'rtl' : 'ltr';
         this.ctx.textAlign = 'left';
         this.ctx.textBaseline = 'alphabetic';
-        const {baseline, middle} = this.fontMetrics.getMetrics(fontFamily, fontSize);
+        const {baseline} = this.fontMetrics.getMetrics(fontFamily, fontSize);
         const paintOrder = styles.paintOrder;
 
         text.textBounds.forEach((text) => {

--- a/src/render/canvas/canvas-renderer.ts
+++ b/src/render/canvas/canvas-renderer.ts
@@ -145,7 +145,16 @@ export class CanvasRenderer extends Renderer {
 
     renderTextWithLetterSpacing(text: TextBounds, letterSpacing: number, baseline: number): void {
         if (letterSpacing === 0) {
-            this.ctx.fillText(text.text, text.bounds.left, text.bounds.top + baseline);
+            // Fixed an issue with characters moving up in non-Firefox.
+            // https://github.com/niklasvh/html2canvas/issues/2107#issuecomment-692462900
+            if (navigator.userAgent.indexOf('Firefox') === -1){
+                // non-Firefox browser add this
+                this.ctx.textBaseline = 'ideographic';
+                this.ctx.fillText(text.text, text.bounds.left, text.bounds.top + text.bounds.height);
+                // this.ctx.fillText(text.text, text.bounds.left, text.bounds.top + baseline);
+            } else {
+                this.ctx.fillText(text.text, text.bounds.left, text.bounds.top + baseline);
+            }
         } else {
             const letters = segmentGraphemes(text.text);
             letters.reduce((left, letter) => {

--- a/src/render/canvas/canvas-renderer.ts
+++ b/src/render/canvas/canvas-renderer.ts
@@ -148,10 +148,8 @@ export class CanvasRenderer extends Renderer {
             // Fixed an issue with characters moving up in non-Firefox.
             // https://github.com/niklasvh/html2canvas/issues/2107#issuecomment-692462900
             if (navigator.userAgent.indexOf('Firefox') === -1){
-                // non-Firefox browser add this
                 this.ctx.textBaseline = 'ideographic';
                 this.ctx.fillText(text.text, text.bounds.left, text.bounds.top + text.bounds.height);
-                // this.ctx.fillText(text.text, text.bounds.left, text.bounds.top + baseline);
             } else {
                 this.ctx.fillText(text.text, text.bounds.left, text.bounds.top + baseline);
             }


### PR DESCRIPTION
**Summary**

<!-- Summary of the PR -->

This PR fixes/implements the following **bugs/features**

* [x] Resolving the line-height issue of TextNode in non-Firefox browsers by utilizing element heights.