### PR TITLE
FIX: img with inlined svg dataUrls are not rendered

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "module": "dist/html2canvas.esm.js",
     "typings": "dist/types/src/index.d.ts",
     "browser": "dist/html2canvas.js",
-    "version": "1.6.3",
+    "version": "1.6.5",
     "keywords": [
         "typescript",
         "html",

--- a/src/core/cache-storage.ts
+++ b/src/core/cache-storage.ts
@@ -113,9 +113,7 @@ export class Cache {
                 src = src + (src.includes('?') ? '&' : '?') + `cors=${Math.random()}`;
             }
             img.src = src;
-            if (/^data:/.test(src)) {
-                resolve(img);
-            } else if (img.complete === true) {
+            if (img.complete === true) {
                 // Inline XML images may fail to parse, throwing an Error later on
                 setTimeout(() => resolve(img), 500);
             }

--- a/src/core/features.ts
+++ b/src/core/features.ts
@@ -166,7 +166,8 @@ export const serializeSvg = (svg: SVGSVGElement | SVGForeignObjectElement, encod
 
 const INLINE_BASE64 = /^data:image\/.*;base64,/i;
 export const deserializeSvg = (svg: string): SVGSVGElement | SVGForeignObjectElement => {
-    const encodedSvg = INLINE_BASE64.test(svg) ? atob(svg) : decodeURIComponent(svg);
+    const [, inlinedSvg] = svg.split(',');
+    const encodedSvg = INLINE_BASE64.test(svg) ? atob(inlinedSvg) : decodeURIComponent(inlinedSvg);
     const domParser = new DOMParser();
     const document = domParser.parseFromString(encodedSvg, 'image/svg+xml');
     const parserError = document.querySelector('parsererror');

--- a/src/dom/replaced-elements/image-element-container.ts
+++ b/src/dom/replaced-elements/image-element-container.ts
@@ -27,8 +27,7 @@ export class ImageElementContainer extends ElementContainer {
             if (this.isSvg()) {
                 resolve();
             } else if (this.isInlinedSvg()) {
-                const [, inlinedSvg] = this.src.split(',');
-                const svgElement = deserializeSvg(inlinedSvg);
+                const svgElement = deserializeSvg(this.src);
                 const {
                     width: {baseVal: widthBaseVal},
                     height: {baseVal: heightBaseVal}
@@ -50,6 +49,7 @@ export class ImageElementContainer extends ElementContainer {
                 if (this.intrinsicWidth && this.intrinsicHeight) {
                     resolve();
                 } else {
+                    //This might never happen, as the image is already loaded after the cache is awaited in canvas-renderer.ts/renderNodeContent, cache-storage.ts/Cache.loadImage does it
                     img.addEventListener('load', (_event) => {
                         this.intrinsicWidth = img.naturalWidth;
                         this.intrinsicHeight = img.naturalHeight;


### PR DESCRIPTION
**Summary**

BUGFIX: img tags with svg dataUrl as src are not rendered. deserializeSvg() allways fails as it gets only the data portion of the dataUrl passed in.

